### PR TITLE
prefix WT

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,9 +6,9 @@
 
 
 ```julia
-using Tutte.Graphs # @nodes Graph Weighted →
+using Tutte.Graphs # @nodes WTGraph Weighted →
 @nodes A B C D E F G
-g = Graph(union(A → C → F → G, A → D → F, B → D → G, B → E → G))
+g = WTGraph(union(A → C → F → G, A → D → F, B → D → G, B → E → G))
 w = Weighted([A 5→ C 2→ F 1→ G], [A 3→ D 4→ F], [B 9→ D 8→ G], [B 6→ E 4→ G])
 w.graph == g
 w.graph.edges.list == [A → C, C → F, F → G, A → D, D → F, B → D, D → G, B → E, E → G]

--- a/docs/make.jl
+++ b/docs/make.jl
@@ -1,6 +1,6 @@
 using Tutte
 using .Tutte.Graphs
-using .Graphs: Graph, Edge, Edges
+using .Graphs: WTGraph, WTEdge, WTEdges
 using Documenter
 
 makedocs(

--- a/docs/src/Graphs.md
+++ b/docs/src/Graphs.md
@@ -1,27 +1,27 @@
 # Graphs
 
-### Graph
+### WTGraph
 ```@docs
-Graphs.Graph
-Graphs.add_edges(g::Graph{T}, edge::Edge{T}) where T
-Graphs.add_edges(g::Graph{T}, edges::Edges{T}) where T
-Graphs.add_edges!(callback, g::Graph{T}, edge::Edge{T}) where T
-Graphs.add_edges!(callback, g::Graph{T}, edges::Edges{T}) where T
-Graphs.remove_edges(g::Graph{T}, edge::Edge{T}) where T
-Graphs.remove_edges(g::Graph{T}, edges::Edges{T}) where T
-Graphs.remove_edges!(callback, g::Graph{T}, edge::Edge{T}) where T
-Graphs.remove_edges!(callback, g::Graph{T}, edges::Edges{T}) where T
+Graphs.WTGraph
+Graphs.add_edges(g::WTGraph{T}, edge::WTEdge{T}) where T
+Graphs.add_edges(g::WTGraph{T}, edges::WTEdges{T}) where T
+Graphs.add_edges!(callback, g::WTGraph{T}, edge::WTEdge{T}) where T
+Graphs.add_edges!(callback, g::WTGraph{T}, edges::WTEdges{T}) where T
+Graphs.remove_edges(g::WTGraph{T}, edge::WTEdge{T}) where T
+Graphs.remove_edges(g::WTGraph{T}, edges::WTEdges{T}) where T
+Graphs.remove_edges!(callback, g::WTGraph{T}, edge::WTEdge{T}) where T
+Graphs.remove_edges!(callback, g::WTGraph{T}, edges::WTEdges{T}) where T
 ```
 
-### Edges
+### WTEdges
 ```@docs
-Graphs.Edges
-Graphs.union(args::Union{Edge{T}, Edges{T}}...) where T
+Graphs.WTEdges
+Graphs.union(args::Union{WTEdge{T}, WTEdges{T}}...) where T
 ```
 
-### Edge
+### WTEdge
 ```@docs
-Graphs.Edge
+Graphs.WTEdge
 Graphs.:⇿
 Graphs.:→
 Graphs.:←
@@ -29,9 +29,9 @@ Graphs.:⇄
 Graphs.:⇆
 ```
 
-### Node
+### WTNode
 ```@docs
-Graphs.Node
+Graphs.WTNode
 Graphs.@nodes
 ```
 
@@ -39,6 +39,6 @@ Graphs.@nodes
 ```@docs
 Graphs.Weighted
 Graphs.add_edges!(callback, w::Weighted{T, WT}, arg::Array{Any, 2}) where {T, WT}
-Graphs.remove_edges!(callback, w::Weighted{T, WT}, edge::Edge{T}) where {T, WT}
-Graphs.remove_edges!(callback, w::Weighted{T, WT}, edges::Edges{T}) where {T, WT}
+Graphs.remove_edges!(callback, w::Weighted{T, WT}, edge::WTEdge{T}) where {T, WT}
+Graphs.remove_edges!(callback, w::Weighted{T, WT}, edges::WTEdges{T}) where {T, WT}
 ```

--- a/docs/src/index.md
+++ b/docs/src/index.md
@@ -1,9 +1,9 @@
 # Tutte ፨
 
 ```julia
-using Tutte.Graphs # @nodes Graph Weighted →
+using Tutte.Graphs # @nodes WTGraph Weighted →
 @nodes A B C D E F G
-g = Graph(union(A → C → F → G, A → D → F, B → D → G, B → E → G))
+g = WTGraph(union(A → C → F → G, A → D → F, B → D → G, B → E → G))
 w = Weighted([A 5→ C 2→ F 1→ G], [A 3→ D 4→ F], [B 9→ D 8→ G], [B 6→ E 4→ G])
 w.graph == g
 w.graph.edges.list == [A → C, C → F, F → G, A → D, D → F, B → D, D → G, B → E, E → G]

--- a/src/Graphs.jl
+++ b/src/Graphs.jl
@@ -1,6 +1,6 @@
 module Graphs # Tutte
 
-export Graph, Edge, Edges, Node, @nodes, ⇿, →, ←, ⇄, ⇆, add_edges, remove_edges, add_edges!, remove_edges!
+export WTGraph, WTEdge, WTEdges, WTNode, @nodes, ⇿, →, ←, ⇄, ⇆, add_edges, remove_edges, add_edges!, remove_edges!
 include("Graphs/graphs.jl")
 
 export Weighted

--- a/src/Graphs/graphs.jl
+++ b/src/Graphs/graphs.jl
@@ -4,37 +4,37 @@ using LightGraphs: AbstractGraph, AbstractEdge
 using Base: Fix2
 
 """
-    Node
+    WTNode
 """
-struct Node
+struct WTNode
     id::Symbol
 end
 
 """
-    Edge{T}
+    WTEdge{T}
 """
-struct Edge{T} <: AbstractEdge{T}
-    op
+struct WTEdge{T} <: AbstractEdge{T}
+    op::Function
     nodes::Tuple{T, T}
     backward::Bool
 end
 
 """
-    Edges{T}
+    WTEdges{T}
 """
-struct Edges{T}
-    list::Vector{Edge{T}}
+struct WTEdges{T}
+    list::Vector{WTEdge{T}}
 
-    # Edges{Node}([])
-    function Edges{T}(list::Vector{Any}) where T
+    # WTEdges{WTNode}([])
+    function WTEdges{T}(list::Vector{Any}) where T
         new{T}(list)
     end
 
-    function Edges{T}(list::Vector{Edge{T}}; isunique=false) where T
+    function WTEdges{T}(list::Vector{WTEdge{T}}; isunique=false) where T
         if isunique
             new{T}(list)
         else
-            edges = Vector{Edge{T}}()
+            edges = Vector{WTEdge{T}}()
             @inbounds for edge in list
                 !(edge in edges) && push!(edges, edge)
             end
@@ -42,47 +42,47 @@ struct Edges{T}
         end
     end
 
-    function Edges(list::Vector{Edge{T}}; isunique=false) where T
-        Edges{T}(list; isunique=isunique)
+    function WTEdges(list::Vector{WTEdge{T}}; isunique=false) where T
+        WTEdges{T}(list; isunique=isunique)
     end
-end # struct Edges{T}
+end # struct WTEdges{T}
 
 """
-    Graph{T}
+    WTGraph{T}
 """
-struct Graph{T} <: AbstractGraph{T}
+struct WTGraph{T} <: AbstractGraph{T}
     nodes::Set{T}
-    edges::Edges{T}
+    edges::WTEdges{T}
 
-    function Graph{T}(nodes::Set{T}, edges::Edges{T}) where T
+    function WTGraph{T}(nodes::Set{T}, edges::WTEdges{T}) where T
         new{T}(nodes, edges)
     end
 
-    function Graph{T}(edges::Edges{T}) where T
-        Graph{T}(allnodes(edges), edges)
+    function WTGraph{T}(edges::WTEdges{T}) where T
+        WTGraph{T}(allnodes(edges), edges)
     end
 
-    function Graph{T}(edge::Edge{T}) where T
-        Graph{T}(Edges([edge]; isunique=true))
+    function WTGraph{T}(edge::WTEdge{T}) where T
+        WTGraph{T}(WTEdges([edge]; isunique=true))
     end
 
-    function Graph{T}() where T
-        Graph{T}(Set{T}(), Edges(Vector{Edge{T}}(), isunique=true))
+    function WTGraph{T}() where T
+        WTGraph{T}(Set{T}(), WTEdges(Vector{WTEdge{T}}(), isunique=true))
     end
 
-    function Graph(nodes::Set{T}, edges::Edges{T}) where T
-        Graph{T}(nodes, edges)
+    function WTGraph(nodes::Set{T}, edges::WTEdges{T}) where T
+        WTGraph{T}(nodes, edges)
     end
 
-    function Graph(edges::Edges{T}) where T
-        Graph{T}(edges)
+    function WTGraph(edges::WTEdges{T}) where T
+        WTGraph{T}(edges)
     end
 
-    function Graph(edge::Edge{T}) where T
-        Graph{T}(Edges([edge]; isunique=true))
+    function WTGraph(edge::WTEdge{T}) where T
+        WTGraph{T}(WTEdges([edge]; isunique=true))
     end
 
-end # struct Graph{T} <: AbstractGraph{T}
+end # struct WTGraph{T} <: AbstractGraph{T}
 
 """
     @nodes
@@ -92,14 +92,14 @@ macro nodes(args...)
 end
 
 function graph_nodes(s)
-    :(($(s...),) = $(map(id -> Node(id), s)))
+    :(($(s...),) = $(map(id -> WTNode(id), s)))
 end
 
-function Base.isempty(g::Graph{T}) where T
+function Base.isempty(g::WTGraph{T}) where T
     isempty(g.nodes) && isempty(g.edges)
 end
 
-function Base.isempty(edges::Edges{T}) where T
+function Base.isempty(edges::WTEdges{T}) where T
     isempty(edges.list)
 end
 
@@ -107,62 +107,62 @@ end
 """
     ⇿
 """
-function ⇿(a::T, b::T)::Edge{T} where T
-    Edge{T}(⇿, (a, b), false)
+function ⇿(a::T, b::T)::WTEdge{T} where T
+    WTEdge{T}(⇿, (a, b), false)
 end
 
 # →  \rightarrow<tab>
 """
     →
 """
-function →(a::T, b::T)::Edge{T} where T
-    Edge{T}(→, (a, b), false)
+function →(a::T, b::T)::WTEdge{T} where T
+    WTEdge{T}(→, (a, b), false)
 end
 
 # ←  \leftarrow<tab>
 """
     ←
 """
-function ←(a::T, b::T)::Edge{T} where T
-    Edge{T}(→, (b, a), true)
+function ←(a::T, b::T)::WTEdge{T} where T
+    WTEdge{T}(→, (b, a), true)
 end
 
 # ⇄  \rightleftarrows<tab>
 """
     ⇄
 """
-function ⇄(a::T, b::T)::Edges{T} where T
-    Edges([→(a, b), ←(a, b)], isunique=true)
+function ⇄(a::T, b::T)::WTEdges{T} where T
+    WTEdges([→(a, b), ←(a, b)], isunique=true)
 end
 
 # ⇆  \leftrightarrows<tab>
 """
     ⇆
 """
-function ⇆(a::T, b::T)::Edges{T} where T
-    Edges([←(a, b), →(a, b)], isunique=true)
+function ⇆(a::T, b::T)::WTEdges{T} where T
+    WTEdges([←(a, b), →(a, b)], isunique=true)
 end
 
-function ⇄(a::T, edge::Edge{T})::Edges{T} where T
-    Edges([⇄(a, nodeof(edge, first)).list..., edge])
+function ⇄(a::T, edge::WTEdge{T})::WTEdges{T} where T
+    WTEdges([⇄(a, nodeof(edge, first)).list..., edge])
 end
 
-function ⇆(a::T, edge::Edge{T})::Edges{T} where T
-    Edges([⇆(a, nodeof(edge, first)).list..., edge])
+function ⇆(a::T, edge::WTEdge{T})::WTEdges{T} where T
+    WTEdges([⇆(a, nodeof(edge, first)).list..., edge])
 end
 
 for arrow in (:⇿, :→, :←)
-    @eval function ($arrow)(a::T, edges::Edges{T})::Edges where T
+    @eval function ($arrow)(a::T, edges::WTEdges{T})::WTEdges where T
         edge = first(edges.list)
-        Edges([$arrow(a, nodeof(edge, first)), edges.list...])
+        WTEdges([$arrow(a, nodeof(edge, first)), edges.list...])
     end
 
-    @eval function ($arrow)(a::T, edge::Edge{T})::Edges where T
-        Edges([$arrow(a, nodeof(edge, first)), edge])
+    @eval function ($arrow)(a::T, edge::WTEdge{T})::WTEdges where T
+        WTEdges([$arrow(a, nodeof(edge, first)), edge])
     end
 
-    @eval function ($arrow)(edge::Edge{T}, b::T)::Edges where T
-        Edges([edge, $arrow(nodeof(edge, last), b)])
+    @eval function ($arrow)(edge::WTEdge{T}, b::T)::WTEdges where T
+        WTEdges([edge, $arrow(nodeof(edge, last), b)])
     end
 end
 
@@ -173,11 +173,11 @@ inverse(::typeof(⇿)) = ⇿
 inverse(::typeof(→)) = ←
 inverse(::typeof(←)) = →
 
-function is_directed(edge::Edge{T}) where T
+function is_directed(edge::WTEdge{T}) where T
     is_directed(edge.op)
 end
 
-function is_directed(edges::Edges{T}) where T
+function is_directed(edges::WTEdges{T}) where T
     isempty(edges) && return false
     @inbounds for edge in edges.list
         !is_directed(edge) && return false
@@ -185,28 +185,28 @@ function is_directed(edges::Edges{T}) where T
     true
 end
 
-function is_directed(g::Graph{T}) where T
+function is_directed(g::WTGraph{T}) where T
     is_directed(g.edges)
 end
 
 """
-    union(args::Union{Edge{T}, Edges{T}}...)::Edges{T} where T
+    union(args::Union{WTEdge{T}, WTEdges{T}}...)::WTEdges{T} where T
 """
-function Base.union(args::Union{Edge{T}, Edges{T}}...)::Edges{T} where T
-    list = Vector{Edge{T}}()
+function Base.union(args::Union{WTEdge{T}, WTEdges{T}}...)::WTEdges{T} where T
+    list = Vector{WTEdge{T}}()
     @inbounds for arg in args
-        if arg isa Edge
+        if arg isa WTEdge
             !(arg in list) && push!(list, arg)
-        elseif arg isa Edges
+        elseif arg isa WTEdges
             for edge in arg.list
                 !(edge in list) && push!(list, edge)
             end
         end
     end
-    Edges(list, isunique=true)
+    WTEdges(list, isunique=true)
 end
 
-function Base.:(==)(a::Edge{T}, b::Edge{T}) where T
+function Base.:(==)(a::WTEdge{T}, b::WTEdge{T}) where T
     if a.op === b.op
         if is_directed(a.op)
             a.nodes == b.nodes
@@ -218,49 +218,49 @@ function Base.:(==)(a::Edge{T}, b::Edge{T}) where T
     end
 end
 
-function Base.:(==)(l::Edges{T}, r::Edges{T}) where T
+function Base.:(==)(l::WTEdges{T}, r::WTEdges{T}) where T
     length(l.list) == length(r.list) || return false
     a = Dict((is_directed(edge.op) ? edge.nodes : Set{T}(edge.nodes)) => edge.op for edge in l.list)
     b = Dict((is_directed(edge.op) ? edge.nodes : Set{T}(edge.nodes)) => edge.op for edge in r.list)
     a == b
 end
 
-function Base.:(==)(l::Graph{T}, r::Graph{T}) where T
+function Base.:(==)(l::WTGraph{T}, r::WTGraph{T}) where T
     l.nodes == r.nodes && l.edges == r.edges
 end
 
-function Base.iterate(edges::Edges{T}, state = 1) where T
+function Base.iterate(edges::WTEdges{T}, state = 1) where T
     iterate(edges.list, state)
 end
 
-function Base.length(edges::Edges{T}) where T
+function Base.length(edges::WTEdges{T}) where T
     length(edges.list)
 end
 
-function Base.push!(edges::Edges{T}, edge::Edge{T}) where T
+function Base.push!(edges::WTEdges{T}, edge::WTEdge{T}) where T
     push!(edges.list, edge)
 end
 
-function Base.empty(::Edges{T}) where T
-    Edges{T}([])
+function Base.empty(::WTEdges{T}) where T
+    WTEdges{T}([])
 end
 
-function Base.empty!(edges::Edges{T}) where T
+function Base.empty!(edges::WTEdges{T}) where T
     empty!(edges.list)
 end
 
 """
-    add_edges(g::Graph{T}, edge::Edge{T})::Graph{T} where T
+    add_edges(g::WTGraph{T}, edge::WTEdge{T})::WTGraph{T} where T
 """
-function add_edges(g::Graph{T}, edge::Edge{T})::Graph{T} where T
-    add_edges(g, Edges([edge], isunique=true))
+function add_edges(g::WTGraph{T}, edge::WTEdge{T})::WTGraph{T} where T
+    add_edges(g, WTEdges([edge], isunique=true))
 end
 
 """
-    add_edges(g::Graph{T}, edges::Edges{T})::Graph{T} where T
+    add_edges(g::WTGraph{T}, edges::WTEdges{T})::WTGraph{T} where T
 """
-function add_edges(g::Graph{T}, edges::Edges{T})::Graph{T} where T
-    list = Vector{Edge{T}}(g.edges.list)
+function add_edges(g::WTGraph{T}, edges::WTEdges{T})::WTGraph{T} where T
+    list = Vector{WTEdge{T}}(g.edges.list)
     nodes = Set{T}(g.nodes)
     @inbounds for edge in edges.list
         if !(edge in g.edges.list)
@@ -268,22 +268,22 @@ function add_edges(g::Graph{T}, edges::Edges{T})::Graph{T} where T
             push!(nodes, edge.nodes...)
         end
     end
-    concatedges = Edges(list, isunique=true)
-    Graph{T}(nodes, concatedges)
+    concatedges = WTEdges(list, isunique=true)
+    WTGraph{T}(nodes, concatedges)
 end
 
 """
-    add_edges!(callback, g::Graph{T}, edge::Edge{T}) where T
+    add_edges!(callback, g::WTGraph{T}, edge::WTEdge{T}) where T
 """
-function add_edges!(callback, g::Graph{T}, edge::Edge{T}) where T
-    add_edges!(callback, g, Edges([edge], isunique=true))
+function add_edges!(callback, g::WTGraph{T}, edge::WTEdge{T}) where T
+    add_edges!(callback, g, WTEdges([edge], isunique=true))
 end
 
 """
-    add_edges!(callback, g::Graph{T}, edges::Edges{T}) where T
+    add_edges!(callback, g::WTGraph{T}, edges::WTEdges{T}) where T
 """
-function add_edges!(callback, g::Graph{T}, edges::Edges{T}) where T
-    list = Vector{Edge{T}}()
+function add_edges!(callback, g::WTGraph{T}, edges::WTEdges{T}) where T
+    list = Vector{WTEdge{T}}()
     nodes = Set{T}()
     @inbounds for edge in edges.list
         if !(edge in g.edges.list)
@@ -299,32 +299,32 @@ function add_edges!(callback, g::Graph{T}, edges::Edges{T}) where T
 end
 
 """
-    remove_edges(g::Graph{T}, edge::Edge{T})::Graph{T} where T
+    remove_edges(g::WTGraph{T}, edge::WTEdge{T})::WTGraph{T} where T
 """
-function remove_edges(g::Graph{T}, edge::Edge{T})::Graph{T} where T
-    remove_edges(g, Edges([edge], isunique=true))
+function remove_edges(g::WTGraph{T}, edge::WTEdge{T})::WTGraph{T} where T
+    remove_edges(g, WTEdges([edge], isunique=true))
 end
 
 """
-    remove_edges(g::Graph{T}, edges::Edges{T})::Graph{T} where T
+    remove_edges(g::WTGraph{T}, edges::WTEdges{T})::WTGraph{T} where T
 """
-function remove_edges(g::Graph{T}, edges::Edges{T})::Graph{T} where T
+function remove_edges(g::WTGraph{T}, edges::WTEdges{T})::WTGraph{T} where T
     list = g.edges.list
     indices = filter(!isnothing, indexin(list, edges.list))
-    Graph{T}(g.nodes, Edges(g.edges.list[setdiff(1:length(list), indices)], isunique=true))
+    WTGraph{T}(g.nodes, WTEdges(g.edges.list[setdiff(1:length(list), indices)], isunique=true))
 end
 
 """
-    remove_edges!(callback, g::Graph{T}, edge::Edge{T}) where T
+    remove_edges!(callback, g::WTGraph{T}, edge::WTEdge{T}) where T
 """
-function remove_edges!(callback, g::Graph{T}, edge::Edge{T}) where T
-    remove_edges!(callback, g, Edges([edge], isunique=true))
+function remove_edges!(callback, g::WTGraph{T}, edge::WTEdge{T}) where T
+    remove_edges!(callback, g, WTEdges([edge], isunique=true))
 end
 
 """
-    remove_edges!(callback, g::Graph{T}, edges::Edges{T}) where T
+    remove_edges!(callback, g::WTGraph{T}, edges::WTEdges{T}) where T
 """
-function remove_edges!(callback, g::Graph{T}, edges::Edges{T}) where T
+function remove_edges!(callback, g::WTGraph{T}, edges::WTEdges{T}) where T
     indices = filter(!isnothing, indexin(g.edges.list, edges.list))
     if length(g.edges.list) != length(indices)
         list = g.edges.list[indices]
@@ -337,25 +337,25 @@ function remove_edges!(callback, g::Graph{T}, edges::Edges{T}) where T
     end
 end
 
-function Base.isless(a::Node, b::Node)
+function Base.isless(a::WTNode, b::WTNode)
     a.id < b.id
 end
 
-function nodeof(edge::Edge{T}, ::typeof(first)) where T
+function nodeof(edge::WTEdge{T}, ::typeof(first)) where T
     edge.backward ? edge.nodes[2] : edge.nodes[1]
 end
 
-function nodeof(edge::Edge{T}, ::typeof(last)) where T
+function nodeof(edge::WTEdge{T}, ::typeof(last)) where T
     edge.backward ? edge.nodes[1] : edge.nodes[2]
 end
 
-function allnodes(edges::Edges{T})::Set{T} where T
+function allnodes(edges::WTEdges{T})::Set{T} where T
     Set{T}(vcat(map(edge -> collect(edge.nodes), edges.list)...))
 end
 
-function Base.show(io::IO, mime::MIME"text/plain", graph::Graph{T}) where T
-    print(io, nameof(Graph), "{", nameof(T), "}(")
-    if graph.nodes isa Set{Node}
+function Base.show(io::IO, mime::MIME"text/plain", graph::WTGraph{T}) where T
+    print(io, nameof(WTGraph), "{", nameof(T), "}(")
+    if graph.nodes isa Set{WTNode}
         Base.show(io, mime, graph.nodes)
     else
         print(io, "Set([")
@@ -371,9 +371,9 @@ function Base.show(io::IO, mime::MIME"text/plain", graph::Graph{T}) where T
     print(io, ")")
 end
 
-function Base.show(io::IO, mime::MIME"text/plain", edges::Edges{T}) where T
+function Base.show(io::IO, mime::MIME"text/plain", edges::WTEdges{T}) where T
     count = length(edges.list)
-    print(io, nameof(Edges), "{", nameof(T), "}([")
+    print(io, nameof(WTEdges), "{", nameof(T), "}([")
     @inbounds for (idx, edge) in enumerate(edges.list)
         Base.show(io, mime, edge)
         count != idx && print(io, ", ")
@@ -381,7 +381,7 @@ function Base.show(io::IO, mime::MIME"text/plain", edges::Edges{T}) where T
     print(io, "])")
 end
 
-function Base.show(io::IO, mime::MIME"text/plain", edge::Edge{T}) where T
+function Base.show(io::IO, mime::MIME"text/plain", edge::WTEdge{T}) where T
     if edge.backward
         op, l, r = inverse(edge.op), last, first
     else
@@ -393,11 +393,11 @@ function Base.show(io::IO, mime::MIME"text/plain", edge::Edge{T}) where T
     Base.show(ioctx, mime, r(edge.nodes))
 end
 
-function Base.show(io::IO, mime::MIME"text/plain", node::Node)
+function Base.show(io::IO, mime::MIME"text/plain", node::WTNode)
     print(io, node.id)
 end
 
-function Base.show(io::IO, mime::MIME"text/plain", nodes::Set{Node})
+function Base.show(io::IO, mime::MIME"text/plain", nodes::Set{WTNode})
     count = length(nodes)
     print(io, nameof(Set), "([")
     @inbounds for (idx, node) in enumerate(sort(collect(nodes)))
@@ -411,7 +411,7 @@ end
 →(node::T) where T = Fix2(→, node)
 ←(node::T) where T = Fix2(←, node)
 
-function mapfilter(pred, f, itr::Vector{Edge{T}}, res::Vector{Edge{T}}) where T
+function mapfilter(pred, f, itr::Vector{WTEdge{T}}, res::Vector{WTEdge{T}}) where T
     @inbounds for edge in itr
         if is_directed(pred.f)
             if pred.f === edge.op
@@ -432,28 +432,28 @@ function mapfilter(pred, f, itr::Vector{Edge{T}}, res::Vector{Edge{T}}) where T
     res
 end
 
-function Base.filter(f::Fix2, list::Vector{Edge{T}}) where T
+function Base.filter(f::Fix2, list::Vector{WTEdge{T}}) where T
     mapfilter(f, push!, list, empty(list))
 end
 
-function Base.filter(f::Fix2, edges::Edges{T}) where T
-    Edges{T}(mapfilter(f, push!, edges.list, empty(edges.list)))
+function Base.filter(f::Fix2, edges::WTEdges{T}) where T
+    WTEdges{T}(mapfilter(f, push!, edges.list, empty(edges.list)))
 end
 
-function Base.replace(graph::Graph{GT}, vertices::Vector{T})::Graph{T} where {GT, T}
+function Base.replace(graph::WTGraph{GT}, vertices::Vector{T})::WTGraph{T} where {GT, T}
     sortednodes = sort(collect(graph.nodes))
-    list = [Edge{T}(edge.op, tuple(vertices[indexin(edge.nodes, sortednodes)]...), edge.backward) for edge in graph.edges.list]
-    Graph{T}(Set{T}(vertices), Edges{T}(list))
+    list = [WTEdge{T}(edge.op, tuple(vertices[indexin(edge.nodes, sortednodes)]...), edge.backward) for edge in graph.edges.list]
+    WTGraph{T}(Set{T}(vertices), WTEdges{T}(list))
 end
 
-function Base.replace(graph::Graph{T}, pairs::Pair{T, T}...)::Graph{T} where T
+function Base.replace(graph::WTGraph{T}, pairs::Pair{T, T}...)::WTGraph{T} where T
     nodes = replace(graph.nodes, pairs...)
-    Graph{T}(nodes, replace(graph.edges, pairs...))
+    WTGraph{T}(nodes, replace(graph.edges, pairs...))
 end
 
-function Base.replace(edges::Edges{T}, pairs::Pair{T, T}...)::Edges{T} where T
-    list = [Edge{T}(edge.op, tuple(replace(collect(edge.nodes), pairs...)...), edge.backward) for edge in edges.list]
-    Edges{T}(list)
+function Base.replace(edges::WTEdges{T}, pairs::Pair{T, T}...)::WTEdges{T} where T
+    list = [WTEdge{T}(edge.op, tuple(replace(collect(edge.nodes), pairs...)...), edge.backward) for edge in edges.list]
+    WTEdges{T}(list)
 end
 
 # module Tutte.Graphs

--- a/src/Graphs/lightgraphs.jl
+++ b/src/Graphs/lightgraphs.jl
@@ -3,7 +3,7 @@
 using LightGraphs.SimpleGraphs: SimpleGraphs, SimpleGraph, SimpleDiGraph, LGFormat
 
 # SimpleGraph
-function simplegraph_nodes(vertices::Vector{T}, edges::Edges{T})::Tuple{SimpleGraph{Int}, Vector{T}} where T
+function simplegraph_nodes(vertices::Vector{T}, edges::WTEdges{T})::Tuple{SimpleGraph{Int}, Vector{T}} where T
     r = SimpleGraph(length(vertices))
     for edge in edges.list
         SimpleGraphs.add_edge!(r, indexin(edge.nodes, vertices)...)
@@ -11,17 +11,17 @@ function simplegraph_nodes(vertices::Vector{T}, edges::Edges{T})::Tuple{SimpleGr
     (r, vertices)
 end
 
-function simplegraph_nodes(edges::Edges{T})::Tuple{SimpleGraph{Int}, Vector{T}} where T
+function simplegraph_nodes(edges::WTEdges{T})::Tuple{SimpleGraph{Int}, Vector{T}} where T
     vertices = sort(collect(allnodes(edges)))
     simplegraph_nodes(vertices, edges)
 end
 
-function simplegraph_nodes(g::Graph{T})::Tuple{SimpleGraph{Int}, Vector{T}} where T
+function simplegraph_nodes(g::WTGraph{T})::Tuple{SimpleGraph{Int}, Vector{T}} where T
     simplegraph_nodes(g.edges)
 end
 
 # SimpleDiGraph
-function simpledigraph_nodes(vertices::Vector{T}, edges::Edges{T})::Tuple{SimpleDiGraph{Int}, Vector{T}} where T
+function simpledigraph_nodes(vertices::Vector{T}, edges::WTEdges{T})::Tuple{SimpleDiGraph{Int}, Vector{T}} where T
     r = SimpleDiGraph(length(vertices))
     for edge in edges.list
         SimpleGraphs.add_edge!(r, indexin(edge.nodes, vertices)...)
@@ -29,49 +29,49 @@ function simpledigraph_nodes(vertices::Vector{T}, edges::Edges{T})::Tuple{Simple
     (r, vertices)
 end
 
-function simpledigraph_nodes(edges::Edges{T})::Tuple{SimpleDiGraph{Int}, Vector{T}} where T
+function simpledigraph_nodes(edges::WTEdges{T})::Tuple{SimpleDiGraph{Int}, Vector{T}} where T
     vertices = sort(collect(allnodes(edges)))
     simpledigraph_nodes(vertices, edges)
 end
 
-function simpledigraph_nodes(g::Graph{T})::Tuple{SimpleDiGraph{Int}, Vector{T}} where T
+function simpledigraph_nodes(g::WTGraph{T})::Tuple{SimpleDiGraph{Int}, Vector{T}} where T
     simpledigraph_nodes(g.edges)
 end
 
-# Graph{T}
-function Graph{T}(sg::SimpleGraph{ST}, nodes::Vector{T})::Graph{T} where {T, ST}
-    Graph{T}(Set{T}(nodes), Edges([Edge(⇿, (nodes[edge.src], nodes[edge.dst]), false) for edge in SimpleGraphs.edges(sg)]))
+# WTGraph{T}
+function WTGraph{T}(sg::SimpleGraph{ST}, nodes::Vector{T})::WTGraph{T} where {T, ST}
+    WTGraph{T}(Set{T}(nodes), WTEdges([WTEdge(⇿, (nodes[edge.src], nodes[edge.dst]), false) for edge in SimpleGraphs.edges(sg)]))
 end
 
-function Graph(sg::SimpleGraph{ST}, nodes::Vector{T})::Graph{T} where {T, ST}
-    Graph{T}(sg, nodes)
+function WTGraph(sg::SimpleGraph{ST}, nodes::Vector{T})::WTGraph{T} where {T, ST}
+    WTGraph{T}(sg, nodes)
 end
 
-function Graph{T}(sg::SimpleGraph{ST})::Graph{T} where {T, ST}
-    Graph{T}(sg, Vector{T}(SimpleGraphs.vertices(sg)))
+function WTGraph{T}(sg::SimpleGraph{ST})::WTGraph{T} where {T, ST}
+    WTGraph{T}(sg, Vector{T}(SimpleGraphs.vertices(sg)))
 end
 
-function Graph(sg::SimpleGraph{T})::Graph{T} where T
-    Graph{T}(sg)
+function WTGraph(sg::SimpleGraph{T})::WTGraph{T} where T
+    WTGraph{T}(sg)
 end
 
-function Graph{T}(sg::SimpleDiGraph{ST}, nodes::Vector{T})::Graph{T} where {T, ST}
-    Graph{T}(Set{T}(nodes), Edges([Edge(→, (nodes[edge.src], nodes[edge.dst]), false) for edge in SimpleGraphs.edges(sg)]))
+function WTGraph{T}(sg::SimpleDiGraph{ST}, nodes::Vector{T})::WTGraph{T} where {T, ST}
+    WTGraph{T}(Set{T}(nodes), WTEdges([WTEdge(→, (nodes[edge.src], nodes[edge.dst]), false) for edge in SimpleGraphs.edges(sg)]))
 end
 
-function Graph{T}(sg::SimpleDiGraph{ST})::Graph{T} where {T, ST}
-    Graph{T}(sg, Vector{T}(SimpleGraphs.vertices(sg)))
+function WTGraph{T}(sg::SimpleDiGraph{ST})::WTGraph{T} where {T, ST}
+    WTGraph{T}(sg, Vector{T}(SimpleGraphs.vertices(sg)))
 end
 
-function Graph(sg::SimpleDiGraph{ST}, nodes::Vector{T})::Graph{T} where {T, ST}
-    Graph{T}(sg, nodes)
+function WTGraph(sg::SimpleDiGraph{ST}, nodes::Vector{T})::WTGraph{T} where {T, ST}
+    WTGraph{T}(sg, nodes)
 end
 
-function Graph(sg::SimpleDiGraph{T})::Graph{T} where T
-    Graph{T}(sg)
+function WTGraph(sg::SimpleDiGraph{T})::WTGraph{T} where T
+    WTGraph{T}(sg)
 end
 
-function savegraph(io::IO, g::AbstractGraph)
+function savegraph(io::IO, g::AbstractGraph{T}) where T
     SimpleGraphs.savegraph(io, g, LGFormat())
 end
 

--- a/src/Graphs/weighted.jl
+++ b/src/Graphs/weighted.jl
@@ -1,9 +1,9 @@
 # module Tutte.Graphs
 
-function push_edge(list::Vector{Edge{T}}, weights, e::Edge{ET}, prev::T) where {T, ET}
+function push_edge(list::Vector{WTEdge{T}}, weights, e::WTEdge{ET}, prev::T) where {T, ET}
     weight = nodeof(e, first)
     second = nodeof(e, last)
-    edge = Edge{T}(e.op, e.backward ? (second, prev) : (prev, second), e.backward)
+    edge = WTEdge{T}(e.op, e.backward ? (second, prev) : (prev, second), e.backward)
     idx = findfirst(==(edge), list)
     if idx === nothing
         push!(list, edge)
@@ -17,33 +17,33 @@ end
     Weighted{T, WT}
 """
 struct Weighted{T, WT} <: AbstractGraph{T}
-    graph::Graph{T}
+    graph::WTGraph{T}
     weights::Vector{WT}
 
     function Weighted{T, WT}() where {T, WT}
-        new{T, WT}(Graph{T}(), Vector{WT}())
+        new{T, WT}(WTGraph{T}(), Vector{WT}())
     end
 
     function Weighted{T, WT}(args::Array{Any,2}...) where {T, WT}
-        list = Vector{Edge{T}}()
+        list = Vector{WTEdge{T}}()
         weights = Vector{WT}()
         @inbounds for arg in args
             prev = first(arg)
             for e in arg[2:end]
-                if e isa Edges
+                if e isa WTEdges
                     for (idx, e2) in enumerate(e.list)
                         push_edge(list, weights, e2, prev)
                         if iseven(idx)
                             prev = nodeof(e2, last)
                         end
                     end
-                elseif e isa Edge
+                elseif e isa WTEdge
                     push_edge(list, weights, e, prev)
                     prev = nodeof(e, last)
                 end
             end
         end
-        graph = Graph(Edges(list; isunique=true))
+        graph = WTGraph(WTEdges(list; isunique=true))
         new{T, WT}(graph, weights)
     end
 
@@ -52,19 +52,19 @@ struct Weighted{T, WT} <: AbstractGraph{T}
         arg = first(args)
         T = typeof(first(arg))
         arg2 = arg[2]
-        if arg2 isa Edge
+        if arg2 isa WTEdge
             WT = typeof(nodeof(arg2, first))
-        elseif arg2 isa Edges
+        elseif arg2 isa WTEdges
             WT = typeof(nodeof(arg2.list[1], first))
         end
         Weighted{T, WT}(args...)
     end
 
-    function Weighted{T, WT}(graph::Graph{T}, weights::Vector{WT}) where {T, WT}
+    function Weighted{T, WT}(graph::WTGraph{T}, weights::Vector{WT}) where {T, WT}
         new{T, WT}(graph, weights)
     end
 
-    function Weighted(graph::Graph{T}, weights::Vector{WT}) where {T, WT}
+    function Weighted(graph::WTGraph{T}, weights::Vector{WT}) where {T, WT}
         Weighted{T, WT}(graph, weights)
     end
 end # struct Weighted{T, WT}
@@ -73,39 +73,39 @@ function Base.isempty(w::Weighted{T, WT}) where {T, WT}
     isempty(w.graph)
 end
 
-function ⇿(a::A, b::B)::Edge{Union{A,B}} where {A, B}
-    Edge{Union{A,B}}(⇿, (a, b), false)
+function ⇿(a::A, b::B)::WTEdge{Union{A,B}} where {A, B}
+    WTEdge{Union{A,B}}(⇿, (a, b), false)
 end
 
-function →(a::A, b::B)::Edge{Union{A,B}} where {A, B}
-    Edge{Union{A,B}}(→, (a, b), false)
+function →(a::A, b::B)::WTEdge{Union{A,B}} where {A, B}
+    WTEdge{Union{A,B}}(→, (a, b), false)
 end
 
-function ←(a::A, b::B)::Edge{Union{A, B}} where {A, B}
-    Edge{Union{A,B}}(→, (b, a), true)
+function ←(a::A, b::B)::WTEdge{Union{A, B}} where {A, B}
+    WTEdge{Union{A,B}}(→, (b, a), true)
 end
 
-function ⇄(a::A, b::B)::Edges{Union{A, B}} where {A, B}
-    Edges([→(a, b), ←(a, b)], isunique=true)
+function ⇄(a::A, b::B)::WTEdges{Union{A, B}} where {A, B}
+    WTEdges([→(a, b), ←(a, b)], isunique=true)
 end
 
-function ⇆(a::A, b::B)::Edges{Union{A, B}} where {A, B}
-    Edges([←(a, b), →(a, b)], isunique=true)
+function ⇆(a::A, b::B)::WTEdges{Union{A, B}} where {A, B}
+    WTEdges([←(a, b), →(a, b)], isunique=true)
 end
 
-function ⇄(a::A, edge::Edge{B})::Edges{Union{A, B}} where {A, B}
-    Edges([⇄(a, nodeof(edge, first)).list..., edge])
+function ⇄(a::A, edge::WTEdge{B})::WTEdges{Union{A, B}} where {A, B}
+    WTEdges([⇄(a, nodeof(edge, first)).list..., edge])
 end
 
-function ⇆(a::A, edge::Edge{B})::Edges{Union{A, B}} where {A, B}
-    Edges([⇆(a, nodeof(edge, first)).list..., edge])
+function ⇆(a::A, edge::WTEdge{B})::WTEdges{Union{A, B}} where {A, B}
+    WTEdges([⇆(a, nodeof(edge, first)).list..., edge])
 end
 
 """
     add_edges!(callback, w::Weighted{T, WT}, arg::Array{Any, 2}) where {T, WT}
 """
 function add_edges!(callback, w::Weighted{T, WT}, arg::Array{Any, 2}) where {T, WT}
-    edges = Vector{Edge{T}}()
+    edges = Vector{WTEdge{T}}()
     weights = Vector{WT}()
     nodes = Set{T}()
     x = Weighted{T, WT}(arg)
@@ -134,16 +134,16 @@ function add_edges!(callback, w::Weighted{T, WT}, arg::Array{Any, 2}) where {T, 
 end
 
 """
-    remove_edges!(callback, w::Weighted{T, WT}, edge::Edge{T}) where {T, WT}
+    remove_edges!(callback, w::Weighted{T, WT}, edge::WTEdge{T}) where {T, WT}
 """
-function remove_edges!(callback, w::Weighted{T, WT}, edge::Edge{T}) where {T, WT}
-    remove_edges!(callback, w, Edges([edge], isunique=true))
+function remove_edges!(callback, w::Weighted{T, WT}, edge::WTEdge{T}) where {T, WT}
+    remove_edges!(callback, w, WTEdges([edge], isunique=true))
 end
 
 """
-    remove_edges!(callback, w::Weighted{T, WT}, edges::Edges{T}) where {T, WT}
+    remove_edges!(callback, w::Weighted{T, WT}, edges::WTEdges{T}) where {T, WT}
 """
-function remove_edges!(callback, w::Weighted{T, WT}, edges::Edges{T}) where {T, WT}
+function remove_edges!(callback, w::Weighted{T, WT}, edges::WTEdges{T}) where {T, WT}
     indices = filter(!isnothing, indexin(w.graph.edges.list, edges.list))
     if length(w.graph.edges.list) != length(indices)
         list = w.graph.edges.list[indices]

--- a/test/tutte/algebraic.jl
+++ b/test/tutte/algebraic.jl
@@ -1,14 +1,14 @@
 module test_tutte_algebraic
 
 using Test
-using Tutte.Graphs # Graph ⇿
+using Tutte.Graphs # WTGraph ⇿
 using Tutte.Graphs: simplegraph_nodes
 using LinearAlgebra: Diagonal
 using LightGraphs: SimpleGraph, adjacency_matrix, laplacian_matrix
 
 # https://en.wikipedia.org/wiki/Laplacian_matrix
 
-graph = Graph(union(1 ⇿ 2 ⇿ 3 ⇿ 4 ⇿ 5 ⇿ 1, 2 ⇿ 5, 4 ⇿ 6))
+graph = WTGraph(union(1 ⇿ 2 ⇿ 3 ⇿ 4 ⇿ 5 ⇿ 1, 2 ⇿ 5, 4 ⇿ 6))
 g, nodes = simplegraph_nodes(graph)
 adj = adjacency_matrix(g)
 lap = laplacian_matrix(g)
@@ -30,6 +30,6 @@ lap = laplacian_matrix(g)
               -1 -1  0 -1  3  0
                0  0  0 -1  0  1]
 
-@test graph == Graph(SimpleGraph(adj))
+@test graph == WTGraph(SimpleGraph(adj))
 
 end # module test_tutte_algebraic

--- a/test/tutte/custom_edge.jl
+++ b/test/tutte/custom_edge.jl
@@ -1,51 +1,51 @@
 module test_tutte_custom_edge
 
 using Test
-using Tutte.Graphs
+using Tutte.Graphs # WTEdges WTEdge
 
-function ↪(a::T, b::T)::Edge{T} where T
-    Edge{T}(↪, (a, b), false)
+function ↪(a::T, b::T)::WTEdge{T} where T
+    WTEdge{T}(↪, (a, b), false)
 end
-function ↩(a::T, b::T)::Edge{T} where T
-    Edge{T}(↪, (b, a), true)
+function ↩(a::T, b::T)::WTEdge{T} where T
+    WTEdge{T}(↪, (b, a), true)
 end
 Graphs.is_directed(::typeof(↪)) = true
 Graphs.is_directed(::typeof(↩)) = true
 Graphs.inverse(::typeof(↪)) = ↩
 Graphs.inverse(::typeof(↩)) = ↪
 for arrow in (:↪ , :↩ )
-    @eval function ($arrow)(a::T, edges::Edges{T})::Edges where T
+    @eval function ($arrow)(a::T, edges::WTEdges{T})::WTEdges where T
         edge = first(edges.list)
-        Edges([$arrow(a, Graphs.nodeof(edge, first)), edges.list...])
+        WTEdges([$arrow(a, Graphs.nodeof(edge, first)), edges.list...])
     end
-    @eval function ($arrow)(a::T, edge::Edge{T})::Edges where T
-        Edges([$arrow(a, Graphs.nodeof(edge, first)), edge])
+    @eval function ($arrow)(a::T, edge::WTEdge{T})::WTEdges where T
+        WTEdges([$arrow(a, Graphs.nodeof(edge, first)), edge])
     end
-    @eval function ($arrow)(edge::Edge{T}, b::T)::Edges where T
-        Edges([edge, $arrow(Graphs.nodeof(edge, last), b)])
+    @eval function ($arrow)(edge::WTEdge{T}, b::T)::WTEdges where T
+        WTEdges([edge, $arrow(WTGraphs.nodeof(edge, last), b)])
     end
 end
 
 @test (1 ↪ 2) == (2 ↩ 1)
 @test (1 ↪ 2 ↪ 3) == (3 ↩ 2 ↩ 1)
-@test union(1 ↪ 2, 1 ↪ 2) == Edges([1 ↪ 2])
-@test (1 ↪ 2) isa Edge{Int}
-@test union(1 → 2, 1 ↪ 2) == Edges([1 → 2, 1 ↪ 2])
+@test union(1 ↪ 2, 1 ↪ 2) == WTEdges([1 ↪ 2])
+@test (1 ↪ 2) isa WTEdge{Int}
+@test union(1 → 2, 1 ↪ 2) == WTEdges([1 → 2, 1 ↪ 2])
 @test Graphs.is_directed(union(1 → 2, 1 ↪ 2))
 
 # Weighted
-function ↪(a::A, b::B)::Edge{Union{A,B}} where {A, B}
-    Edge{Union{A,B}}(↪, (a, b), false)
+function ↪(a::A, b::B)::WTEdge{Union{A,B}} where {A, B}
+    WTEdge{Union{A,B}}(↪, (a, b), false)
 end
-function ↩(a::A, b::B)::Edge{Union{A, B}} where {A, B}
-    Edge{Union{A,B}}(↩, (b, a), true)
+function ↩(a::A, b::B)::WTEdge{Union{A, B}} where {A, B}
+    WTEdge{Union{A,B}}(↩, (b, a), true)
 end
 
 @nodes A B C D
 w = Weighted([A 3↪ B 5↪ C])
 @test w.graph.edges.list == [A ↪ B, B↪ C]
 @test w.weights == [3, 5]
-@test sprint(show, "text/plain", w) == "Weighted{Node, Int64}(Graph{Node}(Set([A, B, C]), Edges{Node}([A ↪ B, B ↪ C])), [3, 5])"
+@test sprint(show, "text/plain", w) == "Weighted{WTNode, Int64}(WTGraph{WTNode}(Set([A, B, C]), WTEdges{WTNode}([A ↪ B, B ↪ C])), [3, 5])"
 
 add_edges!(w, [A -1↪ B 1↪ D]) do edges, weights, nodes
     @test edges == [A ↪  B, B ↪  D]

--- a/test/tutte/filter.jl
+++ b/test/tutte/filter.jl
@@ -1,14 +1,14 @@
 module test_tutte_filter
 
 using Test
-using Tutte.Graphs
+using Tutte.Graphs # WTNode @nodes ⇿ → ←
 
 @nodes A B C D E
 
 @test ⇿(C)(A) == ⇿(A)(C) == (A ⇿ C)
 @test →(D)(C) == ←(C)(D) == (C → D) == (D ← C)
-@test →(D) isa Base.Fix2{typeof(→), Node}
-@test ←(C) isa Base.Fix2{typeof(←), Node}
+@test →(D) isa Base.Fix2{typeof(→), WTNode}
+@test ←(C) isa Base.Fix2{typeof(←), WTNode}
 
 edges = union(A ⇿ C → D, E → D)
 @test filter(⇿(A), edges.list) == [A ⇿ C]

--- a/test/tutte/graphplot.jl
+++ b/test/tutte/graphplot.jl
@@ -1,13 +1,13 @@
 module test_tutte_graphplot
 
 using Test
-using Tutte.Graphs # Graph ⇿ @nodes
+using Tutte.Graphs # WTGraph ⇿ @nodes
 using Tutte.Graphs: simplegraph_nodes
 using LightGraphs.SimpleGraphs: SimpleGraph
 using GraphPlot: spring_layout, graphline
 
 @nodes A B C D E
-graph = Graph(A ⇿ C ⇿ D ⇿ E)
+graph = WTGraph(A ⇿ C ⇿ D ⇿ E)
 g, nodes = simplegraph_nodes(graph)
 locs_x, locs_y = spring_layout(g)
 lines_cord = graphline(g, locs_x, locs_y, 1)

--- a/test/tutte/graphs.jl
+++ b/test/tutte/graphs.jl
@@ -1,93 +1,93 @@
 module test_tutte_graphs
 
 using Test
-using Tutte.Graphs # Graph Edge Edges Node @nodes ⇿ → ←  add_edges remove_edges add_edges! remove_edges!
+using Tutte.Graphs # WTGraph WTEdges WTEdge WTNode @nodes ⇿ → ←  add_edges remove_edges add_edges! remove_edges!
 
-G = Graph{Node}()
+G = WTGraph{WTNode}()
 @nodes A B C D E F
 
 @test isempty(G)
-@test G isa Graph
+@test G isa WTGraph{WTNode}
 
-@test (D ← C) isa Edge
+@test (D ← C) isa WTEdge
 @test (C → D) == (D ← C)
 @test (A ⇿ C) == (C ⇿ A)
 @test (A ⇿ C → D) == (D ← C ⇿ A)
-@test F isa Node
-@test union(C → D, D ← C) == Edges([C → D]) == Edges([D ← C])
-@test union(C → D, D → C) == Edges([C → D, D → C]) == Edges([C → D, C ← D])
-@test union(C → D, D → E, E ⇿ F) == Edges([C → D, D → E, E ⇿ F])
-@test union(C → D, D → E → B) == Edges([C → D, D → E, E → B])
-@test union(C → D, D → E → B, B → F) == Edges([C → D, D → E, E → B, B → F])
+@test F isa WTNode
+@test union(C → D, D ← C) == WTEdges([C → D]) == WTEdges([D ← C])
+@test union(C → D, D → C) == WTEdges([C → D, D → C]) == WTEdges([C → D, C ← D])
+@test union(C → D, D → E, E ⇿ F) == WTEdges([C → D, D → E, E ⇿ F])
+@test union(C → D, D → E → B) == WTEdges([C → D, D → E, E → B])
+@test union(C → D, D → E → B, B → F) == WTEdges([C → D, D → E, E → B, B → F])
 
 @nodes H
-@test H isa Node
-@test H == Node(:H)
+@test H isa WTNode
+@test H == WTNode(:H)
 @test H.id === :H
 
 G = add_edges(G, A ⇿ C)
-@test G.edges == Edges([A ⇿ C])
+@test G.edges == WTEdges([A ⇿ C])
 @test G.nodes == Set([A, C])
-@test sprint(show, "text/plain", G) == "Graph{Node}(Set([A, C]), Edges{Node}([A ⇿ C]))"
+@test sprint(show, "text/plain", G) == "WTGraph{WTNode}(Set([A, C]), WTEdges{WTNode}([A ⇿ C]))"
 @test !isempty(G)
 @test length(G.edges) == 1
 
 G2 = add_edges(G, A ⇿ C → D ← F)
-@test G.edges == Edges([A ⇿ C])
+@test G.edges == WTEdges([A ⇿ C])
 @test G.nodes == Set([A, C])
-@test G2.edges == Edges([A ⇿ C, C → D, D ← F])
+@test G2.edges == WTEdges([A ⇿ C, C → D, D ← F])
 @test G2.nodes == Set([A, C, D, F])
 
 G3 = remove_edges(G2, A ⇿ C)
-@test G.edges == Edges([A ⇿ C])
+@test G.edges == WTEdges([A ⇿ C])
 @test G.nodes == Set([A, C])
-@test G2.edges == Edges([A ⇿ C, C → D, D ← F])
+@test G2.edges == WTEdges([A ⇿ C, C → D, D ← F])
 @test G2.nodes == Set([A, C, D, F])
-@test G3.edges == Edges([C → D, D ← F])
+@test G3.edges == WTEdges([C → D, D ← F])
 @test G3.nodes == Set([A, C, D, F])
 
-@test (1 ⇿ 2) isa Edge
-@test (1 ⇿ 2 ⇿ 3) isa Edges
+@test (1 ⇿ 2) isa WTEdge
+@test (1 ⇿ 2 ⇿ 3) isa WTEdges
 
-G = Graph{Int}()
+G = WTGraph{Int}()
 G2 = add_edges(G, 1 ⇿ 3 → 4 ← 5)
-@test G2.edges == Edges([1 ⇿ 3, 3 → 4, 4 ← 5])
+@test G2.edges == WTEdges([1 ⇿ 3, 3 → 4, 4 ← 5])
 @test G2.nodes == Set([1, 3, 4, 5])
 
-@test (1 ⇄  2) == Edges([1 → 2, 1 ← 2])
-@test (1 ⇆  2) == Edges([1 ← 2, 1 → 2])
-@test (1 ⇆  2 ⇿ 3) == Edges([1 ← 2, 1 → 2, 2 ⇿ 3])
+@test (1 ⇄  2) == WTEdges([1 → 2, 1 ← 2])
+@test (1 ⇆  2) == WTEdges([1 ← 2, 1 → 2])
+@test (1 ⇆  2 ⇿ 3) == WTEdges([1 ← 2, 1 → 2, 2 ⇿ 3])
 
-G = Graph{Node}()
+G = WTGraph{WTNode}()
 add_edges!(G, A ⇿ C) do edges, nodes
     @test edges == [A ⇿ C]
     @test nodes == Set([A, C])
 end
-@test G.edges == Edges([A ⇿ C])
+@test G.edges == WTEdges([A ⇿ C])
 @test G.nodes == Set([A, C])
 add_edges!(G, A ⇿ C → D ← F) do edges, nodes
     @test edges == [C → D, F → D]
     @test nodes == Set([D, F, C])
 end
-@test G.edges == Edges([A ⇿ C, C → D, D ← F])
+@test G.edges == WTEdges([A ⇿ C, C → D, D ← F])
 @test G.nodes == Set([A, C, D, F])
 remove_edges!(G, A ⇿ C) do edges, nodes
     @test edges == [A ⇿ C]
     @test nodes == Set([A, C])
 end
-@test G.edges == Edges([C → D, D ← F])
+@test G.edges == WTEdges([C → D, D ← F])
 @test G.nodes == Set([A, C, D, F])
 
-@test Edge(→, (1, 2), false) isa Edge{Int}
-@test Edge{Int}(→, (1, 2), false) isa Edge{Int}
+@test WTEdge(→, (1, 2), false) isa WTEdge{Int}
+@test WTEdge{Int}(→, (1, 2), false) isa WTEdge{Int}
 
-@test Edges([1 → 2]) isa Edges{Int}
-@test Edges{Int}([1 → 2]) isa Edges{Int}
+@test WTEdges([1 → 2]) isa WTEdges{Int}
+@test WTEdges{Int}([1 → 2]) isa WTEdges{Int}
 
-@test Graph(1 → 2) isa Graph{Int}
-@test Graph{Int}(1 → 2) isa Graph{Int}
-@test Graph(1 → 2 → 3) isa Graph{Int}
-@test Graph{Int}(1 → 2 → 3) isa Graph{Int}
+@test WTGraph(1 → 2) isa WTGraph{Int}
+@test WTGraph{Int}(1 → 2) isa WTGraph{Int}
+@test WTGraph(1 → 2 → 3) isa WTGraph{Int}
+@test WTGraph{Int}(1 → 2 → 3) isa WTGraph{Int}
 
 struct User
     name
@@ -96,12 +96,12 @@ end
 u1 = User("u1", 10)
 u2 = User("u2", 5)
 u3 = User("u3", 1)
-g = Graph(u1 → u2 → u3)
-@test g isa Graph{User}
-@test sprint(show, "text/plain", g.edges) == """Edges{User}([User("u1", 10) → User("u2", 5), User("u2", 5) → User("u3", 1)])"""
+g = WTGraph(u1 → u2 → u3)
+@test g isa WTGraph{User}
+@test sprint(show, "text/plain", g.edges) == """WTEdges{User}([User("u1", 10) → User("u2", 5), User("u2", 5) → User("u3", 1)])"""
 
 @test (1 → 2) == (2 ← 1)
 @test (1 → 2 → 3) == (3 ← 2 ← 1)
-@test union(1 → 2, 1 → 2) == Edges([1 → 2])
+@test union(1 → 2, 1 → 2) == WTEdges([1 → 2])
 
 end # module test_tutte_graphs

--- a/test/tutte/lightgraphs.jl
+++ b/test/tutte/lightgraphs.jl
@@ -1,7 +1,7 @@
 module test_tutte_lightgraphs
 
 using Test
-using Tutte.Graphs # ⇿ → ←
+using Tutte.Graphs # WTGraph ⇿ → ←
 using Tutte.Graphs: simplegraph_nodes, simpledigraph_nodes
 using LightGraphs.SimpleGraphs: SimpleGraph, SimpleDiGraph, SimpleEdge, nv, ne, vertices, edges, dfs_tree, bfs_tree
 
@@ -9,8 +9,8 @@ r, nodes = simplegraph_nodes(1 ⇿ 3 ⇿ 4 ⇿ 5)
 @test r isa SimpleGraph{Int}
 @test nodes == [1, 3, 4, 5]
 @test (4, 3) == (nv(r), ne(r))
-@test Graph(r, nodes) == Graph(1 ⇿ 3 ⇿ 4 ⇿ 5)
-@test Graph(r) == Graph(1 ⇿ 2 ⇿ 3 ⇿ 4)
+@test WTGraph(r, nodes) == WTGraph(1 ⇿ 3 ⇿ 4 ⇿ 5)
+@test WTGraph(r) == WTGraph(1 ⇿ 2 ⇿ 3 ⇿ 4)
 buf = IOBuffer()
 Graphs.savegraph(buf, r)
 @test String(take!(buf)) == "4,3,u,graph,2,Int64,simplegraph\n1,2\n2,3\n3,4\n"
@@ -20,7 +20,7 @@ buf = IOBuffer("4,3,u,graph,2,Int64,simplegraph\n1,2\n2,3\n3,4\n")
 r, nodes = simpledigraph_nodes(1 → 3 → 4 ←  5)
 @test r isa SimpleDiGraph{Int}
 @test (4, 3) == (nv(r), ne(r))
-@test Graph(r) == Graph(1 → 2 → 3 ←  4)
+@test WTGraph(r) == WTGraph(1 → 2 → 3 ←  4)
 buf = IOBuffer()
 Graphs.savegraph(buf, r)
 @test String(take!(buf)) == "4,3,d,graph,2,Int64,simplegraph\n1,2\n2,3\n4,3\n"
@@ -28,7 +28,7 @@ buf = IOBuffer("4,3,d,graph,2,Int64,simplegraph\n1,2\n2,3\n4,3\n")
 @test r == Graphs.loadgraph(buf)
 
 @nodes A B C D E F
-graph = Graph(union(A → C → D → E, C → E ← F))
+graph = WTGraph(union(A → C → D → E, C → E ← F))
 g, nodes = simpledigraph_nodes(graph)
 @test vertices(g) == Base.OneTo(5)
 
@@ -36,7 +36,7 @@ tree = dfs_tree(g, 1)
 @test tree isa SimpleDiGraph{Int}
 @test findfirst(==(C), nodes) == 2
 
-graph = Graph(union(1 → 3 → 4 → 5, 3 → 5 ← 6, 3 ← 2))
+graph = WTGraph(union(1 → 3 → 4 → 5, 3 → 5 ← 6, 3 ← 2))
 g, nodes = simpledigraph_nodes(graph)
 @test vertices(g) == Base.OneTo(6)
 
@@ -51,7 +51,7 @@ b = bfs_tree(g, 3)
 @test collect(edges(b)) == [SimpleEdge(3, 4), SimpleEdge(3, 5)]
 
 
-graph = Graph(union(1 ⇿ 3 ⇿ 4 ⇿ 5, 3 ⇿ 5 ⇿ 6, 3 ⇿ 2))
+graph = WTGraph(union(1 ⇿ 3 ⇿ 4 ⇿ 5, 3 ⇿ 5 ⇿ 6, 3 ⇿ 2))
 g, nodes = simplegraph_nodes(graph)
 @test vertices(g) == Base.OneTo(6)
 

--- a/test/tutte/modular_decomposition.jl
+++ b/test/tutte/modular_decomposition.jl
@@ -1,12 +1,12 @@
 module test_tutte_modular_decomposition
 
 using Test
-using Tutte.Graphs # Graph ⇿ @nodes
+using Tutte.Graphs # WTGraph ⇿ @nodes
 using Tutte.Graphs: simplegraph_nodes
 using LightGraphs: SimpleGraph, adjacency_matrix
 using GraphModularDecomposition: StrongModuleTree
 
-graph = Graph(union(1 ⇿ 2 ⇿ 3 ⇿ 4 ⇿ 5 ⇿ 1, 2 ⇿ 5, 4 ⇿ 6, 6 ⇿ 1, 6 ⇿ 2))
+graph = WTGraph(union(1 ⇿ 2 ⇿ 3 ⇿ 4 ⇿ 5 ⇿ 1, 2 ⇿ 5, 4 ⇿ 6, 6 ⇿ 1, 6 ⇿ 2))
 g, nodes = simplegraph_nodes(graph)
 @test nodes == [1, 2, 3, 4, 5, 6]
 adj = adjacency_matrix(g)
@@ -14,7 +14,7 @@ tree = StrongModuleTree(adj)
 @test repr(sort!(tree)) == "{1 2 3 4 (5 6)}"
 
 @nodes A B C D E F
-graph = Graph(union(A ⇿ B ⇿ C ⇿ D ⇿ E ⇿ A, B ⇿ E, D ⇿ F, F ⇿ A, F ⇿ B))
+graph = WTGraph(union(A ⇿ B ⇿ C ⇿ D ⇿ E ⇿ A, B ⇿ E, D ⇿ F, F ⇿ A, F ⇿ B))
 g, nodes = simplegraph_nodes(graph)
 @test nodes == [A, B, C, D, E, F]
 adj = adjacency_matrix(g)

--- a/test/tutte/replace.jl
+++ b/test/tutte/replace.jl
@@ -1,7 +1,7 @@
 module test_tutte_replace
 
 using Test
-using Tutte.Graphs # Graph @nodes ⇿ →
+using Tutte.Graphs # WTGraph @nodes ⇿ →
 
 @nodes A B C D E F
 
@@ -9,8 +9,8 @@ edges = A ⇿ C → D
 @test replace(edges, D => F) == (A ⇿ C → F)
 @test replace(edges, D => F, A => F) == (F ⇿ C → F)
 
-graph = Graph(edges)
-@test replace(graph, D => F) == Graph(A ⇿ C → F)
-@test replace(graph, D => F, A => F) == Graph(F ⇿ C → F)
+graph = WTGraph(edges)
+@test replace(graph, D => F) == WTGraph(A ⇿ C → F)
+@test replace(graph, D => F, A => F) == WTGraph(F ⇿ C → F)
 
 end # module test_tutte_replace

--- a/test/tutte/self_edge.jl
+++ b/test/tutte/self_edge.jl
@@ -1,9 +1,9 @@
 module test_tutte_self_edge
 
 using Test
-using Tutte.Graphs # Edge → ⇿
+using Tutte.Graphs # WTEdge → ⇿
 
-isselfedge(edge::Edge) = ==(edge.nodes...)
+isselfedge(edge::WTEdge) = ==(edge.nodes...)
 
 @test isselfedge(1 → 1)
 @test !isselfedge(1 → 2)

--- a/test/tutte/weighted.jl
+++ b/test/tutte/weighted.jl
@@ -1,7 +1,7 @@
 module test_tutte_weighted
 
 using Test
-using Tutte.Graphs # Weighted Node @nodes → ← ⇿ ⇄  ⇆
+using Tutte.Graphs # Weighted WTNode @nodes → ← ⇿ ⇄  ⇆
 
 @nodes A B C D E F G
 
@@ -13,7 +13,7 @@ w2 = Weighted([A 5⇿ C 2⇿ F 1⇿ G], [A 3⇿ D 4⇿ F], [B 9⇿ D 8⇿ G], [B
 @test w2.graph.edges.list == [A ⇿ C, C ⇿ F, F ⇿ G, A ⇿ D, D ⇿ F, B ⇿ D, D ⇿ G, B ⇿ E, E ⇿ G]
 @test w2.weights == [5, 2, 1, 3, 4, 9, 8, 6, 4]
 
-w3 = Weighted{Node, Int}()
+w3 = Weighted{WTNode, Int}()
 @test isempty(w3)
 @test isempty(w3.graph)
 @test isempty(w3.weights)
@@ -76,6 +76,6 @@ w11 = Weighted([1 Weight(5)⇿ 2], [1 Weight(-2)⇿ 2])
 @test w11 isa Weighted{Int, Weight}
 @test w11.graph.edges.list == [1 ⇿ 2]
 @test w11.weights == [Weight(3)]
-@test sprint(show, "text/plain", w11) == "Weighted{Int64, Weight}(Graph{Int64}(Set([2, 1]), Edges{Int64}([1 ⇿ 2])), [Weight(3)])"
+@test sprint(show, "text/plain", w11) == "Weighted{Int64, Weight}(WTGraph{Int64}(Set([2, 1]), WTEdges{Int64}([1 ⇿ 2])), [Weight(3)])"
 
 end # module test_tutte_weighted


### PR DESCRIPTION
https://en.wikipedia.org/wiki/W._T._Tutte

> Simon Schoelly
> Some pointers from what I have understood so far:
> - You seem to want to have compatibility with LightGraphs. But you also export names such as `Graph` and `Edge` in `Tutte.Graphs`. This might lead to some annoyances when also importing LightGraphs, as that library also exports these names
> - You have a struct `Edge`, that has a field `op`. What is that field for? And if you would also parametrize the type of that field, you might get better performance
> - It is nice, that you can construct a graph with `\rightarrow` and so on, but it might be a lot of effort to type these. Maybe you could also have some kind of macro that translates statements such as `A -> B -> C` where `->` consists of Asci characters. Or you could use tring literals: `graph"A -> B -> C`. You could also thing about adopting a subset of the dot language (Graphviz) for that
> - Someone who visits your github page, might probably not realize why he should use your graph library instead of LightGraphs, maybe add some information on advantages and disadvantages